### PR TITLE
Slowed clocks from 150MHz to 120MHz

### DIFF
--- a/receivers/native/arm/no-os/src/main/c++/main/main.cpp
+++ b/receivers/native/arm/no-os/src/main/c++/main/main.cpp
@@ -90,12 +90,12 @@ void doNothing(I2c *i2c, I2cTerminationStatus status) {
 }
 
 int main(void) {
-    ClockManager::getClock(VCO)->set(300000, HSI);
-    ClockManager::getClock(PLL_R)->set(150000, VCO);
-    ClockManager::getClock(SysClock)->set(150000, PLL_R);
-    ClockManager::getClock(HCLK)->set(150000, SysClock);
-    ClockManager::getClock(PCLK_1)->set(64000, HCLK);
-    ClockManager::getClock(PCLK_2)->set(64000, HCLK);
+    ClockManager::getClock(VCO)->set(240000, HSI);
+    ClockManager::getClock(PLL_R)->set(120000, VCO);
+    ClockManager::getClock(SysClock)->set(120000, PLL_R);
+    ClockManager::getClock(HCLK)->set(120000, SysClock);
+    ClockManager::getClock(PCLK_1)->set(60000, HCLK);
+    ClockManager::getClock(PCLK_2)->set(60000, HCLK);
     ZcodePinInterruptSource::init();
     ZcodePinInterruptSource source;
     DmaManager::init();


### PR DESCRIPTION
Fixed issues with ARM deployment caused by running the clocks as fast as they could be run. There are probably options for speeds between 150MHz and 120MHz, should they be required. 
There is also the option of range 1 boost mode, which should allow up to 170MHz.